### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/ICLoader/README.md
+++ b/Pods/ICLoader/README.md
@@ -2,7 +2,7 @@ A simple frosty loader, similar to the one used in the <a href="https://github.c
 
 ![Weather Report](http://www.typhoonframework.org/images/portfolio/PocketForecast3.gif)
 
-#Setup
+# Setup
 
 ```Objective-C
 
@@ -14,7 +14,7 @@ A simple frosty loader, similar to the one used in the <a href="https://github.c
 [ICLoader setFontname:aFontName];
 ```
 
-#Usage
+# Usage
 
 ```Objective-C
 [ICLoader present];
@@ -26,7 +26,7 @@ A simple frosty loader, similar to the one used in the <a href="https://github.c
 
 ICLoader is presented in the root view controller's view. 
 
-#Installation
+# Installation
 
 Installation is via <a href="http://www.cocoapods.org/?q=ICLoader">CocoaPods</a>.
 

--- a/Pods/NSURL+QueryDictionary/README.md
+++ b/Pods/NSURL+QueryDictionary/README.md
@@ -20,46 +20,46 @@ The methods returning URL instances have `withSortedKeys:` partner methods that 
 
 Queries with empty values are converted to `NSNull` and vice versa as of `v0.0.5`.
 
-##Version history
+## Version history
 
-###v1.1.0
+### v1.1.0
 
 * Now has methods to create URL copies with the query removed, or replaced with a specified query dictionary.
 
-###v1.0.3
+### v1.0.3
 
 Bug fixes courtesy of [Jan Berkel](https://github.com/jberkel), [Elliot Chance](https://github.com/elliotchance) and [Grzegorz Nowicki](https://github.com/wikia-gregor). [1](https://github.com/itsthejb/NSURL-QueryDictionary/pull/6), [2](https://github.com/itsthejb/NSURL-QueryDictionary/pull/7), [3](https://github.com/itsthejb/NSURL-QueryDictionary/pull/5).
 
-###v1.0.2
+### v1.0.2
 
 * Added category prefixes at the suggestion of [Mike Abdullah](https://github.com/mikeabdullah).
 * Now compiles for OSX 10.8, with thanks to [Elliot Chance](https://github.com/elliotchance).
 
-###v0.0.7
+### v0.0.7
 
 Fixed a potential issue/static analyser false positive with thanks to [Adam Lickel](https://github.com/lickel).
 
-###v0.0.6
+### v0.0.6
 
 Added optional flag to sort the dictionary's keys alphabetically when generating the URL. This makes the generated URLs more deterministic, which helps (for example) if you are running unit tests to inspect your URLs and would like to test the absolute string, rather than having to recreate a query dictionary.
 
-###v0.0.5
+### v0.0.5
 
 Covered an additional empty value case - URL query component has separator, but empty value.
 
-###v0.0.4
+### v0.0.4
 
 Added handling for keys with no value, empty value or `NSNull`.
 
-###v0.0.3
+### v0.0.3
 
 Split the query string parsing components out into `NSString` and `NSDictionary` categories for additional flexibility.
 
-###v0.0.2
+### v0.0.2
 
 Added support for dictionary keys other than NSString. Currently just uses `-description`, but this is ok for `NSNumber` and `NSDate` and a few others, so may be sufficient.
 
-###v0.0.1
+### v0.0.1
 
 Initial release.
 

--- a/Pods/Typhoon/README.md
+++ b/Pods/Typhoon/README.md
@@ -37,9 +37,9 @@ let viewControler = assembly.recommendationController() as! RecommendationContro
 
 Typhoon is available through <a href="http://cocoapods.org/?q=Typhoon">CocoaPods</a> or <a href="https://github.com/Carthage/Carthage">Carthage</a>, and also builds easily from source.
 
-##With CocoaPods . . . 
+## With CocoaPods . . . 
 
-###Static Library
+### Static Library
 
 ```ruby
 
@@ -53,7 +53,7 @@ pod 'Typhoon'
 end
 ```
 
-###Dynamic Framework
+### Dynamic Framework
 
 If you're using Swift, you may wish to install dynamic frameworks, which can be done with the Podfile shown below: 
 
@@ -74,13 +74,13 @@ Simply import the Typhoon module in any Swift file that uses the framework:
 import Typhoon
 ```
 
-##With Carthage
+## With Carthage
 
 ```
 github "appsquickly/Typhoon"
 ```
 
-##From Source
+## From Source
 
 Alternatively, add the source files to your project's target or set up an Xcode workspace. 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An example application built with <a href ="http://typhoonframework.org/">Typhoo
 
 * Looking for an Objective-C sample application? We <a href="https://github.com/appsquickly/Typhoon-example">have one here</a>. 
 
-###Features: 
+### Features: 
 
 * Returns weather reports from a remote cloud service
 * Caches weather reports locally, for later off-line use. 
@@ -16,7 +16,7 @@ An example application built with <a href ="http://typhoonframework.org/">Typhoo
 
 ***NB: The free weather API that we were using no longer includes forecast information, so this won't be displayed in the app until we find an alternative. The concepts remain the same.***
 
-###Running the sample:
+### Running the sample:
 
 * Clone this repository, open the Xcode project in your favorite IDE, and run it. It'll say you need an API key.
 * Get an API key from https://developer.worldweatheronline.com/ 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
